### PR TITLE
Add time capture to data system analysis output

### DIFF
--- a/Assets/Scenes/Common/Scripts/DataCaptureSystem.cs
+++ b/Assets/Scenes/Common/Scripts/DataCaptureSystem.cs
@@ -114,6 +114,7 @@ public class DataCaptureSystem : MonoBehaviour
         List<string> eventsOfInterest = new List<string>
         {
             "frame",
+            "time",
             "acceleration",
             "deceleration",
             "jump",
@@ -151,6 +152,11 @@ public class DataCaptureSystem : MonoBehaviour
 
             foreach (string line in group)
             {
+                if (currentFrame["time"] == "FALSE")
+                {
+                    // Keep the time of the first log.
+                    currentFrame["time"] = line.Split('\t')[1];
+                }
                 string[] lineSplit = line.Split(separator);
                 string eventName = lineSplit[2];
                 string value = lineSplit[3];


### PR DESCRIPTION
As part of this, I benchmarked the stability of time per frame:

mean time per frame: 0.016735938425103614 
variance in time per frame: 7.090182782936143e-06 
standard error of the mean in time per frame: 6.479088182480133e-05

- Resolves #45 